### PR TITLE
Permit tagged templates for no-unused-expressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,6 +209,10 @@ module.exports = {
     ],
     'no-trailing-spaces': 2,
     'no-underscore-dangle': 0,
+    'no-unused-expressions': [2, {
+      // We will be using these a lot as Prisma does not support PostGIS yet
+      'allowTaggedTemplates': true,
+    }],
     'no-whitespace-before-property': 2,
     'object-curly-newline': [
       2,


### PR DESCRIPTION
@jpraccio0722 I couldn't find a prisma file to test on, but i copied it right from the docs (just changed `error` to `2`) so i assume it's correct: 

https://eslint.org/docs/latest/rules/no-unused-expressions#allowtaggedtemplates

Remember in feast you'll need to `pnpm i` again (or possibly `pnpm rm @earth-optics/eslint-config-typescript-react`, and then restore that line in root package.json and then `pnpm i` again 😓).

haven't found a better way to do that, but obvi I/we should be using tagged versions more consistently in these eslint shared repos.